### PR TITLE
merge hotfixes for ouster driver

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+[unreleased]
+============
+* [BUGFIX]: correctly align timestamps to the generated point cloud.
+
 ouster_ros v0.13.2
 ==================
 * [BUGFIX]: Make sure to initialize the sensor with launch file parameters.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,11 @@
 Changelog
 =========
 
-ouster_ros v0.13.1
+ouster_ros v0.13.2
 ==================
 * [BUGFIX]: Make sure to initialize the sensor with launch file parameters.
+* [BUGFIX]: ``os_driver`` failed when RAW option is used.
+
 
 ouster_ros v0.13.0
 ==================

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.2</version>
+  <version>0.13.3</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -200,12 +200,14 @@ class OusterDriver : public OusterSensor {
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
 
         publish_raw = impl::check_token(tokens, "RAW");
+        if (publish_raw)
+            OusterSensor::create_publishers();
     }
 
     virtual void on_lidar_packet_msg(const LidarPacket& lidar_packet) override {
         if (lidar_packet_handler)
             lidar_packet_handler(lidar_packet);
-        
+
         if (publish_raw)
             OusterSensor::on_lidar_packet_msg(lidar_packet);
     }
@@ -213,8 +215,8 @@ class OusterDriver : public OusterSensor {
     virtual void on_imu_packet_msg(const ImuPacket& imu_packet) override {
         if (imu_packet_handler)
             imu_pub->publish(imu_packet_handler(imu_packet));
-        
-        if(publish_raw)
+
+        if (publish_raw)
             OusterSensor::on_imu_packet_msg(imu_packet);
     }
 

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -75,8 +75,6 @@ class OusterPcap : public OusterSensorNodeBase {
         RCLCPP_DEBUG(get_logger(), "on_activate() is called.");
         LifecycleNode::on_activate(state);
         create_publishers();
-        if (imu_packet_pub) imu_packet_pub->on_activate();
-        if (lidar_packet_pub) lidar_packet_pub->on_activate();
         allocate_buffers();
         start_packet_read_thread();
         return LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -278,10 +276,8 @@ class OusterPcap : public OusterSensorNodeBase {
     std::shared_ptr<PcapReader> pcap;
     ouster_sensor_msgs::msg::PacketMsg lidar_packet;
     ouster_sensor_msgs::msg::PacketMsg imu_packet;
-    rclcpp_lifecycle::LifecyclePublisher<ouster_sensor_msgs::msg::PacketMsg>::SharedPtr
-        lidar_packet_pub;
-    rclcpp_lifecycle::LifecyclePublisher<ouster_sensor_msgs::msg::PacketMsg>::SharedPtr
-        imu_packet_pub;
+    rclcpp::Publisher<ouster_sensor_msgs::msg::PacketMsg>::SharedPtr lidar_packet_pub;
+    rclcpp::Publisher<ouster_sensor_msgs::msg::PacketMsg>::SharedPtr imu_packet_pub;
 
     std::atomic<bool> packet_read_active = {false};
     std::unique_ptr<std::thread> packet_read_thread;

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -769,11 +769,10 @@ void OusterSensor::create_publishers() {
 
 void OusterSensor::allocate_buffers() {
     auto& pf = sensor::get_format(info);
-
-    lidar_packet_msg.buf.resize(pf.lidar_packet_size);
     lidar_packet.buf.resize(pf.lidar_packet_size);
+    lidar_packet_msg.buf.resize(pf.lidar_packet_size);
     imu_packet.buf.resize(pf.imu_packet_size);
-    imu_packet.buf.resize(pf.imu_packet_size);
+    imu_packet_msg.buf.resize(pf.imu_packet_size);
 }
 
 bool OusterSensor::init_id_changed(const sensor::packet_format& pf,

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -117,10 +117,9 @@ using Cloud = pcl::PointCloud<T>;
 // TODO[UN]: make this a functor
 template <std::size_t N, const ChanFieldTable<N>& PROFILE, typename PointT,
           typename PointS>
-void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud,
-                     PointS& staging_point,
-                     const ouster::PointsF& points,
-                     uint64_t scan_ts, const ouster::LidarScan& ls,
+void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
+                     const ouster::PointsF& points, uint64_t scan_ts,
+                     const ouster::LidarScan& ls,
                      const std::vector<int>& pixel_shift_by_row,
                      bool organized = false, bool destagger = true,
                      int rows_step = 1) {
@@ -132,11 +131,12 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud,
 
     for (auto u = 0; u < ls.h; u += rows_step) {
         for (auto v = 0; v < ls.w; ++v) {   // TODO[UN]: consider cols_step in future
-            const auto v_shift = destagger ?
-                (v + ls.w - pixel_shift_by_row[u]) % ls.w : v;
+            const auto v_shift =
+                destagger ? (v + ls.w - pixel_shift_by_row[u]) % ls.w : v;
             const auto src_idx = u * ls.w + v_shift;
             const auto xyz = points.row(src_idx);
-            const auto tgt_idx = organized ? (u / rows_step) * ls.w + v : cloud.size();
+            const auto tgt_idx =
+                organized ? (u / rows_step) * ls.w + v : cloud.size();
 
             if (xyz.isNaN().any()) {
                 if (organized) {
@@ -148,12 +148,15 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud,
                 }
                 continue;
             } else {
-                if (!organized)
-                    cloud.points.emplace_back();
+                if (!organized) cloud.points.emplace_back();
             }
 
-            auto ts = timestamp[v_shift];
-            ts = ts > scan_ts ? ts - scan_ts : 0UL;
+            // as opposed to the point cloud destaggering if it is disabled
+            // then timestamps needs to be staggered.
+            auto ts_idx =
+                destagger ? v : (v + ls.w + pixel_shift_by_row[u]) % ls.w;
+            auto ts =
+                timestamp[ts_idx] > scan_ts ? timestamp[ts_idx] - scan_ts : 0UL;
 
             // if target point and staging point has matching type bind the
             // target directly and avoid performing transform_point at the end


### PR DESCRIPTION
merge hotfixes from upstream, mainly to prevent the ouster driver from crashing when the RAW proc mask is set in the driver params